### PR TITLE
Support ArtBench dataset and add data visualization

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 class CFG:
     debug = False
-    image_path = "Moein/AI/Datasets/Flicker-8k/Images"
-    captions_path = "Moein/AI/Datasets/Flicker-8k"
+    image_path = "Moein/AI/Datasets/Flicker-8k/Images"  # unused for ArtBench
+    captions_path = "Moein/AI/Datasets/Flicker-8k"      # unused for ArtBench
+    # location of ArtBench10 pickled batches
+    dataset_root = "artbench-10-python/artbench-10-batches-py"
     batch_size = 32
     num_workers = 4
     head_lr = 1e-3

--- a/dataset.py
+++ b/dataset.py
@@ -1,3 +1,14 @@
+import os
+import pickle
+
+import albumentations as A
+import cv2
+import numpy as np
+import torch
+
+import config as CFG
+
+
 class CLIPDataset(torch.utils.data.Dataset):
     def __init__(self, image_filenames, captions, tokenizer, transforms):
         """
@@ -30,6 +41,52 @@ class CLIPDataset(torch.utils.data.Dataset):
 
     def __len__(self):
         return len(self.captions)
+
+
+class ArtBenchDataset(torch.utils.data.Dataset):
+    """Dataset loader for ArtBench10 pickled batches."""
+
+    def __init__(self, root, tokenizer, transforms, train=True):
+        self.transforms = transforms
+        self.tokenizer = tokenizer
+
+        with open(os.path.join(root, "meta"), "rb") as f:
+            meta = pickle.load(f, encoding="latin1")
+        self.styles = meta["styles"]
+
+        self.images = []
+        self.labels = []
+
+        if train:
+            batch_files = [f"data_batch_{i}" for i in range(1, 6)]
+        else:
+            batch_files = ["test_batch"]
+
+        for bf in batch_files:
+            with open(os.path.join(root, bf), "rb") as f:
+                batch = pickle.load(f, encoding="latin1")
+            self.images.append(batch["data"])
+            self.labels.extend(batch["labels"])
+
+        self.images = np.concatenate(self.images, axis=0).reshape(-1, 3, 32, 32)
+        self.captions = [self.styles[idx] for idx in self.labels]
+
+        self.encoded_captions = tokenizer(
+            self.captions, padding=True, truncation=True, max_length=CFG.max_length
+        )
+
+    def __len__(self):
+        return len(self.captions)
+
+    def __getitem__(self, idx):
+        item = {
+            key: torch.tensor(val[idx]) for key, val in self.encoded_captions.items()
+        }
+        image = self.images[idx].transpose(1, 2, 0)
+        image = self.transforms(image=image)["image"]
+        item["image"] = torch.tensor(image).permute(2, 0, 1).float()
+        item["caption"] = self.captions[idx]
+        return item
 
 
 

--- a/visualize_data.py
+++ b/visualize_data.py
@@ -1,0 +1,35 @@
+import os
+import pickle
+import numpy as np
+import matplotlib.pyplot as plt
+
+import config as CFG
+
+
+def load_sample(index=0):
+    root = CFG.dataset_root
+    with open(os.path.join(root, "meta"), "rb") as f:
+        meta = pickle.load(f, encoding="latin1")
+    styles = meta["styles"]
+
+    with open(os.path.join(root, "data_batch_1"), "rb") as f:
+        batch = pickle.load(f, encoding="latin1")
+
+    images = batch["data"].reshape(-1, 3, 32, 32)
+    labels = batch["labels"]
+
+    img = images[index].transpose(1, 2, 0)
+    caption = styles[labels[index]]
+    return img.astype(np.uint8), caption
+
+
+def main():
+    image, caption = load_sample(0)
+    plt.imshow(image)
+    plt.title(caption)
+    plt.axis("off")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adapt config to include `dataset_root`
- extend `dataset.py` with `ArtBenchDataset`
- update training script to load the ArtBench dataset
- provide `visualize_data.py` to plot images with captions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3bae946c83259ed3ee22dfcffd6c