### PR TITLE
Support ArtBench 256x256 dataset

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,14 @@
+import torch
+
+
 class CFG:
     debug = False
     image_path = "Moein/AI/Datasets/Flicker-8k/Images"  # unused for ArtBench
     captions_path = "Moein/AI/Datasets/Flicker-8k"      # unused for ArtBench
-    # location of ArtBench10 pickled batches
-    dataset_root = "artbench-10-python/artbench-10-batches-py"
+    # location of ArtBench10 dataset
+    # for the 256x256 version download it from Kaggle and set this path
+    dataset_root = "artbench-10-256"
+    dataset_type = "folder"  # 'binary' for 32x32 pickled batches, 'folder' for image folders
     batch_size = 32
     num_workers = 4
     head_lr = 1e-3

--- a/train.py
+++ b/train.py
@@ -8,16 +8,21 @@ from torch import nn
 from transformers import DistilBertTokenizer
 
 import config as CFG
-from dataset import ArtBenchDataset, get_transforms
+from dataset import ArtBenchDataset, ArtBenchImageFolderDataset, get_transforms
 from CLIP import CLIPModel
 from utils import AvgMeter, get_lr
 
 
 def build_loaders(tokenizer):
-    train_dataset = ArtBenchDataset(
+    dataset_cls = (
+        ArtBenchImageFolderDataset
+        if CFG.dataset_type == "folder"
+        else ArtBenchDataset
+    )
+    train_dataset = dataset_cls(
         CFG.dataset_root, tokenizer, get_transforms("train"), train=True
     )
-    valid_dataset = ArtBenchDataset(
+    valid_dataset = dataset_cls(
         CFG.dataset_root, tokenizer, get_transforms("valid"), train=False
     )
 


### PR DESCRIPTION
## Summary
- add config option for using the 256x256 ArtBench image dataset
- implement `ArtBenchImageFolderDataset` to load images from style folders
- switch loader in training script based on `dataset_type`

## Testing
- `python -m py_compile config.py dataset.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_687b409e23708325934a53de33e5e1e5