### PR TITLE
Switch training to Flickr8k dataset

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,14 +1,12 @@
+import os
 import torch
 
 
 class CFG:
     debug = False
-    image_path = "Moein/AI/Datasets/Flicker-8k/Images"  # unused for ArtBench
-    captions_path = "Moein/AI/Datasets/Flicker-8k"      # unused for ArtBench
-    # location of ArtBench10 dataset
-    # for the 256x256 version download it from Kaggle and set this path
-    dataset_root = "artbench-10-256"
-    dataset_type = "folder"  # 'binary' for 32x32 pickled batches, 'folder' for image folders
+    dataset_root = "Moein/AI/Datasets/Flicker-8k"
+    image_path = os.path.join(dataset_root, "Images")
+    captions_path = dataset_root
     batch_size = 32
     num_workers = 4
     head_lr = 1e-3


### PR DESCRIPTION
## Summary
- update configuration for Flickr8k dataset paths
- allow `CLIPDataset` to accept custom image root and add helpers to load Flickr8k
- modify training script to use Flickr8k dataset
- show a few sample image/caption pairs before training starts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b4b490ea08325bfcc9044f175994f