### PR TITLE
Integrate Node backend with Next.js image search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ htmlcov/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Backend vector store
+backend/vector_store.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# CLIP Image Search Demo
+
+This demo integrates a small Node.js backend with a Next.js
+frontend for text–to–image search using a CLIP model.
+
+## Setup
+
+1. **Generate the vector store**
+
+   Pre-compute image embeddings and save them to `backend/vector_store.json`:
+
+   ```bash
+   python3 vector_store.py
+   ```
+
+   The script loads the images listed in `my-app/public/image_paths.csv`,
+   computes embeddings using the model from `best.pt` and stores them
+   for later use.
+
+2. **Start the inference backend**
+
+   ```bash
+   node backend/index.js
+   ```
+
+   The server loads the vector store on start and exposes two endpoints:
+
+   - `GET /init` – loads embeddings if not yet loaded
+   - `GET /search?q=<text>` – returns the filename of the best matching image
+
+3. **Run the Next.js frontend**
+
+   ```bash
+   cd my-app
+   npm run dev
+   ```
+
+   Visiting `http://localhost:3000/images` will trigger `/api/init` to load the
+   embeddings. Submitting text in the search bar calls `/api/search` which
+   proxies to the backend to obtain the best matching image.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,96 @@
+const http = require('http');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const PORT = 8000;
+let vectorStore = null;
+
+function loadVectorStore() {
+  const file = path.join(__dirname, 'vector_store.json');
+  if (!fs.existsSync(file)) {
+    console.error('Vector store not found:', file);
+    return;
+  }
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  vectorStore = data;
+  console.log(`Loaded ${data.filenames.length} image embeddings`);
+}
+
+function cosineSimilarity(vecA, vecB) {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < vecA.length; i++) {
+    dot += vecA[i] * vecB[i];
+    normA += vecA[i] * vecA[i];
+    normB += vecB[i] * vecB[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function handleSearch(query, res) {
+  if (!vectorStore) {
+    loadVectorStore();
+    if (!vectorStore) {
+      res.writeHead(500, {'Content-Type':'application/json'});
+      res.end(JSON.stringify({error:'Vector store not loaded'}));
+      return;
+    }
+  }
+  const py = spawn('python3', [path.join(__dirname, '..', 'inference.py'), '--encode', query]);
+  let output = '';
+  py.stdout.on('data', (d) => { output += d.toString(); });
+  py.stderr.on('data', (d) => { console.error(d.toString()); });
+  py.on('close', (code) => {
+    if (code !== 0) {
+      res.writeHead(500, {'Content-Type':'application/json'});
+      res.end(JSON.stringify({error:'Python error'}));
+      return;
+    }
+    try {
+      const result = JSON.parse(output.trim());
+      const queryVec = result.embedding;
+      let bestScore = -Infinity;
+      let bestIndex = -1;
+      for (let i = 0; i < vectorStore.embeddings.length; i++) {
+        const score = cosineSimilarity(queryVec, vectorStore.embeddings[i]);
+        if (score > bestScore) {
+          bestScore = score;
+          bestIndex = i;
+        }
+      }
+      const image = vectorStore.filenames[bestIndex];
+      res.writeHead(200, {'Content-Type':'application/json'});
+      res.end(JSON.stringify({ image }));
+    } catch (e) {
+      console.error('Failed to parse python output', e);
+      res.writeHead(500, {'Content-Type':'application/json'});
+      res.end(JSON.stringify({error:'Invalid output'}));
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname === '/search' && url.searchParams.has('q')) {
+    const query = url.searchParams.get('q');
+    handleSearch(query, res);
+  } else if (url.pathname === '/init') {
+    loadVectorStore();
+    res.writeHead(200, {'Content-Type':'application/json'});
+    if (vectorStore) {
+      res.end(JSON.stringify({status:'ok', count: vectorStore.filenames.length}));
+    } else {
+      res.end(JSON.stringify({status:'failed'}));
+    }
+  } else {
+    res.writeHead(404, {'Content-Type':'application/json'});
+    res.end(JSON.stringify({error:'Not found'}));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Inference backend running on http://localhost:${PORT}`);
+  loadVectorStore();
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/my-app/app/api/init/route.ts
+++ b/my-app/app/api/init/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  try {
+    const res = await fetch('http://localhost:8000/init')
+    const data = await res.json()
+    return NextResponse.json(data)
+  } catch (err) {
+    console.error('Init error', err)
+    return NextResponse.json({ error: 'Init failed' }, { status: 500 })
+  }
+}

--- a/my-app/app/api/search/route.ts
+++ b/my-app/app/api/search/route.ts
@@ -1,9 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { promisify } from 'util'
-import { execFile } from 'child_process'
-import path from 'path'
-
-const execFileAsync = promisify(execFile)
 
 export async function GET(req: NextRequest) {
   const query = req.nextUrl.searchParams.get('q')
@@ -11,10 +6,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Missing query' }, { status: 400 })
   }
   try {
-    const scriptPath = path.join(process.cwd(), '..', 'inference.py')
-    const { stdout } = await execFileAsync('python3', [scriptPath, '--query', query, '--top', '1'])
-    const data = JSON.parse(stdout.trim())
-    return NextResponse.json({ image: data.matches[0] })
+    const res = await fetch(`http://localhost:8000/search?q=${encodeURIComponent(query)}`)
+    const data = await res.json()
+    return NextResponse.json(data)
   } catch (err) {
     console.error('Search error', err)
     return NextResponse.json({ error: 'Inference failed' }, { status: 500 })

--- a/my-app/app/images/page.tsx
+++ b/my-app/app/images/page.tsx
@@ -51,6 +51,8 @@ const ImagesPage = () => {
   ].filter(img => img.endsWith('.JPG'));
 
   React.useEffect(() => {
+    // initialize backend vector store
+    fetch('/api/init').catch(err => console.error('Init failed', err));
     loadImagePaths('/image_paths.csv')
       .then(paths => {
         if (paths.length > 0) {

--- a/vector_store.py
+++ b/vector_store.py
@@ -1,0 +1,19 @@
+import json
+import torch
+import torch.nn.functional as F
+from inference import load_flickr_data, get_image_embeddings
+from config import CFG
+
+if __name__ == '__main__':
+    image_names, comments = load_flickr_data()
+    CFG.image_path = 'my-app/public/images'
+    model_path = 'best.pt'
+    model, image_embeddings, subset_filenames = get_image_embeddings(image_names, comments, model_path)
+    image_embeddings = F.normalize(image_embeddings, p=2, dim=-1).cpu().tolist()
+    data = {
+        'filenames': subset_filenames,
+        'embeddings': image_embeddings
+    }
+    with open('backend/vector_store.json', 'w') as f:
+        json.dump(data, f)
+    print(f'Saved {len(subset_filenames)} embeddings to backend/vector_store.json')


### PR DESCRIPTION
## Summary
- implement a simple Node.js backend (`backend/index.js`) that loads pre-computed image embeddings and queries `inference.py` for text embeddings
- add script `vector_store.py` for generating `backend/vector_store.json`
- expose `/init` and `/search` API routes in Next.js that proxy to the backend
- page initializes vector store on load and uses real search endpoint
- document workflow in new `README.md`
- ignore generated `vector_store.json`

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f323149688325a66ab5adfc9a6c1e