### PR TITLE
Add startup script for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ frontend for text–to–image search using a CLIP model.
 
 ## Setup
 
+For a quick start you can run `python stupbackend.py`. This script will generate
+the vector store if it does not exist and then launch the inference backend.
+After it is running you only need to start the Next.js frontend.
+
 1. **Generate the vector store**
 
    Pre-compute image embeddings and save them to `backend/vector_store.json`:

--- a/stupbackend.py
+++ b/stupbackend.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import sys
+
+VECTOR_STORE = os.path.join('backend', 'vector_store.json')
+
+
+def ensure_vector_store():
+    """Generate the vector store if it doesn't exist."""
+    if os.path.exists(VECTOR_STORE):
+        print('Vector store already exists. Skipping generation.')
+        return
+    print('Vector store not found. Generating embeddings...')
+    result = subprocess.run([sys.executable, 'vector_store.py'])
+    if result.returncode != 0:
+        raise RuntimeError('Failed to generate vector store')
+
+
+def start_backend():
+    """Start the Node.js inference server."""
+    print('Starting inference backend...')
+    proc = subprocess.Popen(['node', os.path.join('backend', 'index.js')])
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        print('Stopping backend...')
+        proc.terminate()
+        proc.wait()
+
+
+def main():
+    ensure_vector_store()
+    start_backend()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `stupbackend.py` to build the vector store and launch the backend automatically
- update README with quick start instructions

## Testing
- `python -m py_compile stupbackend.py`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3521011c83258c2205127647c86f