### PR TITLE
Add configurable backend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ After it is running you only need to start the Next.js frontend.
    node backend/index.js
    ```
 
+   The server listens on `PORT` (default `8000`).
+
    The server loads the vector store on start and exposes two endpoints:
 
    - `GET /init` – loads embeddings if not yet loaded
@@ -34,11 +36,15 @@ After it is running you only need to start the Next.js frontend.
 
 3. **Run the Next.js frontend**
 
+   Set `BACKEND_URL` to the address of the inference server if it is not running
+   on the same machine:
+
    ```bash
+   export BACKEND_URL=http://<backend-host>:8000
    cd my-app
    npm run dev
    ```
 
    Visiting `http://localhost:3000/images` will trigger `/api/init` to load the
    embeddings. Submitting text in the search bar calls `/api/search` which
-   proxies to the backend to obtain the best matching image.
+   proxies to the backend using `BACKEND_URL` to obtain the best matching image.

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { spawn } = require('child_process');
 const path = require('path');
 
-const PORT = 8000;
+const PORT = process.env.PORT || 8000;
 let vectorStore = null;
 
 function loadVectorStore() {

--- a/my-app/app/api/init/route.ts
+++ b/my-app/app/api/init/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
+  const base = process.env.BACKEND_URL || 'http://localhost:8000'
   try {
-    const res = await fetch('http://localhost:8000/init')
+    const res = await fetch(`${base}/init`)
     const data = await res.json()
     return NextResponse.json(data)
   } catch (err) {

--- a/my-app/app/api/search/route.ts
+++ b/my-app/app/api/search/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
+  const base = process.env.BACKEND_URL || 'http://localhost:8000'
   const query = req.nextUrl.searchParams.get('q')
   if (!query) {
     return NextResponse.json({ error: 'Missing query' }, { status: 400 })
   }
   try {
-    const res = await fetch(`http://localhost:8000/search?q=${encodeURIComponent(query)}`)
+    const res = await fetch(`${base}/search?q=${encodeURIComponent(query)}`)
     const data = await res.json()
     return NextResponse.json(data)
   } catch (err) {


### PR DESCRIPTION
## Summary
- make backend port configurable via `PORT`
- expose `BACKEND_URL` variable in API routes and docs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f37a192d0832580ee384aad7f208c