### PR TITLE
Add HPC notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,30 @@ After it is running you only need to start the Next.js frontend.
    `http://localhost:3000/images` in your browser. Submitting text in the search
    bar will call `/api/search` which proxies to the backend to retrieve the best
    matching image.
+
+## Running on HPC (e.g. NERSC Perlmutter)
+
+When using an interactive compute node you will typically want to forward ports
+so that the frontend and backend are reachable from your local machine.  One
+approach is to open an SSH tunnel before launching the demo:
+
+```bash
+ssh -L 3000:localhost:3000 -L 8000:localhost:8000 <user>@perlmutter.nersc.gov
+```
+
+After connecting, generate the vector store and start the services as usual:
+
+```bash
+python3 vector_store.py        # only needed once
+BACKEND_URL=http://localhost:8000 ./scripts/start.sh
+```
+
+You can then browse to `http://localhost:3000/images` on your local machine.
+If you encounter connection errors, verify that both ports are listening using:
+
+```bash
+python3 scripts/check_ports.py
+```
+
+The script will report whether the backend and frontend are reachable on the
+expected ports.

--- a/scripts/check_ports.py
+++ b/scripts/check_ports.py
@@ -1,0 +1,31 @@
+import socket
+import sys
+
+PORTS = [8000, 3000]
+
+
+def check(port, host='localhost', timeout=2.0):
+    s = socket.socket()
+    s.settimeout(timeout)
+    try:
+        s.connect((host, port))
+        s.close()
+        return True
+    except Exception as e:
+        print(f"Port {port} not reachable: {e}")
+        return False
+
+
+def main():
+    ok = True
+    for port in PORTS:
+        if check(port):
+            print(f"Port {port} is open")
+        else:
+            ok = False
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document port forwarding and startup steps for HPC environment
- add `scripts/check_ports.py` helper to verify connectivity

## Testing
- `pytest -q`
- `python3 scripts/check_ports.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4815d4488325b86a19155a115c79