### PR TITLE
Enable CPU/MPS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ After it is running you only need to start the Next.js frontend.
 
    The script loads the images listed in `my-app/public/image_paths.csv`,
    computes embeddings using the model from `best.pt` and stores them
-   for later use.
+   for later use. A GPU is *not* required to search once the vector store is
+   created; the code automatically selects CUDA, Apple's MPS, or falls back to
+   the CPU depending on what is available on your machine.
 
 2. **Start both backend and frontend**
 

--- a/config.py
+++ b/config.py
@@ -16,7 +16,12 @@ class CFG:
     patience = 1
     factor = 0.8
     epochs = 6
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     model_name = 'resnet50'
     image_embedding = 2048


### PR DESCRIPTION
## Summary
- document that a GPU isn't required to use the demo
- autodetect CUDA/MPS/CPU in config

## Testing
- `python test.py` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687f4b06f0808325a56f7575c1e3e03f