### PR TITLE
Enable DDP and add caption generation example

### DIFF
--- a/train_transfer_caption.py
+++ b/train_transfer_caption.py
@@ -1,9 +1,15 @@
 import os
 import random
+import time
+from typing import List
+
+import cv2
 from tqdm import tqdm
 
 import torch
 from torch import nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import init_process_group, destroy_process_group
 
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
@@ -50,6 +56,31 @@ class CLIPTransferCaptionModel(nn.Module):
         outputs = self.lm(inputs_embeds=inputs_embeds, attention_mask=attn_mask, labels=input_ids)
         return outputs.loss
 
+    @torch.no_grad()
+    def generate_captions(self, image_paths: List[str], tokenizer, max_length: int = 50):
+        """Generate captions for a list of image paths."""
+        self.eval()
+        images = []
+        for p in image_paths:
+            img = cv2.imread(os.path.join(CFG.image_path, p))
+            if img is None:
+                continue
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            img = get_transforms("valid")(image=img)["image"]
+            images.append(torch.tensor(img).permute(2, 0, 1).float())
+
+        if not images:
+            return []
+        batch = torch.stack(images).to(next(self.parameters()).device)
+        img_feat = self.clip.image_encoder(batch)
+        clip_embed = self.clip.image_projection(img_feat)
+        prefix = self.transfer_head(clip_embed)
+        attention_mask = torch.ones(prefix.size(0), 1, device=prefix.device)
+        generated = self.lm.generate(inputs_embeds=prefix.unsqueeze(1), attention_mask=attention_mask, max_length=max_length)
+        captions = tokenizer.batch_decode(generated, skip_special_tokens=True)
+        self.train()
+        return captions
+
 
 def split_data(image_names, captions, train_ratio=0.8, val_ratio=0.1):
     data = list(zip(image_names, captions))
@@ -64,70 +95,116 @@ def split_data(image_names, captions, train_ratio=0.8, val_ratio=0.1):
     return list(train_images), list(train_captions), list(val_images), list(val_captions)
 
 
-def build_loaders(train_images, train_captions, val_images, val_captions, tokenizer):
+def build_loaders(train_images, train_captions, val_images, val_captions, tokenizer, ddp=False):
     train_dataset = CLIPDataset(train_images, train_captions, tokenizer, get_transforms("train"))
     val_dataset = CLIPDataset(val_images, val_captions, tokenizer, get_transforms("valid"))
+
+    train_sampler = torch.utils.data.distributed.DistributedSampler(train_dataset) if ddp else None
+    val_sampler = torch.utils.data.distributed.DistributedSampler(val_dataset, shuffle=False) if ddp else None
+
     train_loader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=CFG.batch_size, num_workers=CFG.num_workers, shuffle=True
+        train_dataset,
+        batch_size=CFG.batch_size,
+        num_workers=CFG.num_workers,
+        shuffle=(train_sampler is None),
+        sampler=train_sampler,
     )
     val_loader = torch.utils.data.DataLoader(
-        val_dataset, batch_size=CFG.batch_size, num_workers=CFG.num_workers, shuffle=False
+        val_dataset,
+        batch_size=CFG.batch_size,
+        num_workers=CFG.num_workers,
+        shuffle=False,
+        sampler=val_sampler,
     )
     return train_loader, val_loader
 
 
-def train_epoch(model, loader, optimizer):
+def train_epoch(model, loader, optimizer, device, master_process=True):
     loss_meter = AvgMeter()
-    progress = tqdm(loader, total=len(loader))
+    progress = tqdm(loader, total=len(loader)) if master_process else loader
     for batch in progress:
-        batch = {k: v.to(CFG.device) for k, v in batch.items() if k != "caption"}
+        batch = {k: v.to(device) for k, v in batch.items() if k != "caption"}
         loss = model(batch)
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
         count = batch["image"].size(0)
         loss_meter.update(loss.item(), count)
-        progress.set_postfix(loss=loss_meter.avg, lr=get_lr(optimizer))
+        if master_process:
+            progress.set_postfix(loss=loss_meter.avg, lr=get_lr(optimizer))
     return loss_meter
 
 
-def valid_epoch(model, loader):
+def valid_epoch(model, loader, device, master_process=True):
     loss_meter = AvgMeter()
-    progress = tqdm(loader, total=len(loader))
+    progress = tqdm(loader, total=len(loader)) if master_process else loader
     for batch in progress:
-        batch = {k: v.to(CFG.device) for k, v in batch.items() if k != "caption"}
+        batch = {k: v.to(device) for k, v in batch.items() if k != "caption"}
         with torch.no_grad():
             loss = model(batch)
         count = batch["image"].size(0)
         loss_meter.update(loss.item(), count)
-        progress.set_postfix(loss=loss_meter.avg)
+        if master_process:
+            progress.set_postfix(loss=loss_meter.avg)
     return loss_meter
 
 
 def main():
+    ddp = int(os.environ.get("RANK", -1)) != -1
+    if ddp:
+        init_process_group(backend="nccl")
+        ddp_rank = int(os.environ["RANK"])
+        ddp_local_rank = int(os.environ["LOCAL_RANK"])
+        device = f"cuda:{ddp_local_rank}"
+        torch.cuda.set_device(device)
+        master_process = ddp_rank == 0
+    else:
+        device = CFG.device
+        master_process = True
+
+    if master_process:
+        print(f"Using device: {device}")
+
     image_names, captions = load_flickr_data()
     train_images, train_captions, val_images, val_captions = split_data(image_names, captions)
 
     tokenizer = AutoTokenizer.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
     tokenizer.pad_token = tokenizer.eos_token
 
-    train_loader, val_loader = build_loaders(train_images, train_captions, val_images, val_captions, tokenizer)
+    train_loader, val_loader = build_loaders(train_images, train_captions, val_images, val_captions, tokenizer, ddp=ddp)
 
-    model = CLIPTransferCaptionModel().to(CFG.device)
+    model = CLIPTransferCaptionModel().to(device)
+    if ddp:
+        model = DDP(model, device_ids=[ddp_local_rank])
+
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4, weight_decay=CFG.weight_decay)
 
     best_loss = float("inf")
     for epoch in range(CFG.epochs):
-        print(f"Epoch {epoch + 1}/{CFG.epochs}")
+        if master_process:
+            print(f"Epoch {epoch + 1}/{CFG.epochs}")
+        if ddp:
+            train_loader.sampler.set_epoch(epoch)
         model.train()
-        train_loss = train_epoch(model, train_loader, optimizer)
+        train_loss = train_epoch(model, train_loader, optimizer, device, master_process)
         model.eval()
-        valid_loss = valid_epoch(model, val_loader)
-        if valid_loss.avg < best_loss:
-            best_loss = valid_loss.avg
-            torch.save(model.state_dict(), "transfer_caption_best.pt")
-            print("Saved best model")
-        print(f"Train Loss: {train_loss.avg:.4f} | Val Loss: {valid_loss.avg:.4f}")
+        valid_loss = valid_epoch(model, val_loader, device, master_process)
+        if master_process:
+            if valid_loss.avg < best_loss:
+                best_loss = valid_loss.avg
+                torch.save(model.module.state_dict() if ddp else model.state_dict(), "transfer_caption_best.pt")
+                print("Saved best model")
+            print(f"Train Loss: {train_loss.avg:.4f} | Val Loss: {valid_loss.avg:.4f}")
+
+    raw_model = model.module if ddp else model
+    sample_images = val_images[:5]
+    captions_out = raw_model.generate_captions(sample_images, tokenizer)
+    if master_process:
+        for img, cap in zip(sample_images, captions_out):
+            print(f"{img} -> {cap}")
+
+    if ddp:
+        destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add distributed training utilities to `train_transfer_caption.py`
- implement `generate_captions` for sampling images after training
- update loaders and training loops to work with DDP

## Testing
- `python -m py_compile train_transfer_caption.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68841377dcb48325bcc01b65fa130dc4